### PR TITLE
fix: migrate release workflow to trunk-based main pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,13 @@
 name: Release
+
 on:
   push:
-    branches:
-      - main
-  workflow_dispatch:
-    inputs:
-      version-bump:
-        description: 'Version bump type'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-        default: minor
+    branches: [main]
 
 jobs:
-  prepare-release:
-    name: Prepare Release
-    if: github.event_name == 'workflow_dispatch'
-    uses: ArkeonProject/organization-tools/.github/workflows/release-prepare.yml@v1.1.5
-    with:
-      version-bump: ${{ github.event.inputs.version-bump }}
-      project-type: 'python'
-      base-branch: 'develop'
-    secrets: inherit
-
-  publish-release:
+  publish:
     name: Publish Release
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    uses: ArkeonProject/organization-tools/.github/workflows/release-publish.yml@v1.1.5
+    uses: ArkeonProject/organization-tools/.github/workflows/release-publish.yml@main
     with:
-      project-type: 'python'
       create-github-release: true
-      auto-back-merge: true
     secrets: inherit


### PR DESCRIPTION
## Summary
- Replaces the legacy release workflow wiring (`release-prepare` + pinned `release-publish@v1.1.5`) with the current organization-tools trunk-based release template.
- Runs release publishing directly on push to `main` using `ArkeonProject/organization-tools/.github/workflows/release-publish.yml@main`.
- Removes outdated inputs and options tied to release branches (`project-type`, `base-branch`, and `auto-back-merge`).

## Why
The old workflow attempted to recreate an already existing release tag (`v4.3.0`) because it depended on static version parsing. The new organization-tools release flow computes the next version from conventional commits on `main`, avoiding duplicate-release failures.