### PR TITLE
fix: ensure Navidrome playlist additions work in production

### DIFF
--- a/backend/src/youtube_watcher/navidrome_client.py
+++ b/backend/src/youtube_watcher/navidrome_client.py
@@ -120,16 +120,29 @@ class NavidromeClient:
             return playlist_id
         return None
 
-    def update_playlist(self, playlist_id: str, name: Optional[str] = None, 
-                       song_ids: Optional[list[str]] = None) -> bool:
+    def update_playlist(
+        self,
+        playlist_id: str,
+        name: Optional[str] = None,
+        song_ids_to_add: Optional[list[str]] = None,
+        song_indexes_to_remove: Optional[list[int]] = None,
+    ) -> bool:
         """Update a playlist (add/remove songs, rename)"""
         params = {"playlistId": playlist_id}
         if name:
             params["name"] = name
-        if song_ids is not None:
-            params["songId"] = song_ids
+        if song_ids_to_add:
+            params["songIdToAdd"] = song_ids_to_add
+        if song_indexes_to_remove:
+            params["songIndexToRemove"] = song_indexes_to_remove
 
         result = self._make_request("updatePlaylist", params)
+        return result is not None
+
+    def start_scan(self, full_scan: bool = False) -> bool:
+        """Trigger a Navidrome library scan"""
+        params = {"fullScan": "true"} if full_scan else None
+        result = self._make_request("startScan", params)
         return result is not None
 
     def delete_playlist(self, playlist_id: str) -> bool:

--- a/backend/src/youtube_watcher/watcher.py
+++ b/backend/src/youtube_watcher/watcher.py
@@ -5,6 +5,7 @@ YouTube Playlist Watcher - Clase principal para monitoreo continuo usando SQLite
 import logging
 import time
 import shutil
+import unicodedata
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict
@@ -344,19 +345,22 @@ class YouTubeWatcher:
             
             client = NavidromeClient(navidrome_url, navidrome_user, navidrome_password)
 
-            # Search by youtube_id first, then fallback to title
-            songs = client.search_songs(youtube_id)
-            if not songs:
-                songs = client.search_songs(title)
-            navidrome_song_id = None
-            
-            for song in songs:
-                if song.get("title") == title or youtube_id in song.get("comment", ""):
-                    navidrome_song_id = song.get("id")
-                    break
-            
+            navidrome_song_id = self._find_navidrome_song_id(client, youtube_id, title)
+
             if not navidrome_song_id:
-                logger.debug(f"Could not find '{title}' in Navidrome, skipping playlist addition")
+                client.start_scan()
+                for _ in range(5):
+                    time.sleep(3)
+                    navidrome_song_id = self._find_navidrome_song_id(client, youtube_id, title)
+                    if navidrome_song_id:
+                        break
+
+            if not navidrome_song_id:
+                logger.warning(
+                    "Could not find '%s' (youtube_id=%s) in Navidrome after scan/retries, skipping playlist addition",
+                    title,
+                    youtube_id,
+                )
                 return
 
             # Add to global playlist if configured
@@ -394,9 +398,8 @@ class YouTubeWatcher:
             
             if song_id in current_song_ids:
                 return
-            
-            all_song_ids = current_song_ids + [song_id]
-            success = client.update_playlist(playlist_id, song_ids=all_song_ids)
+
+            success = client.update_playlist(playlist_id, song_ids_to_add=[song_id])
             
             if success:
                 logger.info(f"✅ Added '{title}' to Navidrome playlist '{playlist_label}'")
@@ -405,3 +408,24 @@ class YouTubeWatcher:
                 
         except Exception as e:
             logger.error(f"Error adding '{title}' to Navidrome playlist '{playlist_label}': {e}")
+
+    @staticmethod
+    def _normalize_string(value: str) -> str:
+        normalized = unicodedata.normalize("NFKD", value or "")
+        return "".join(ch for ch in normalized if not unicodedata.combining(ch)).strip().casefold()
+
+    def _find_navidrome_song_id(self, client, youtube_id: str, title: str) -> str | None:
+        songs = client.search_songs(youtube_id)
+        if not songs:
+            songs = client.search_songs(title)
+
+        normalized_title = self._normalize_string(title)
+        for song in songs:
+            comment = str(song.get("comment", ""))
+            song_title = str(song.get("title", ""))
+            if youtube_id and youtube_id in comment:
+                return song.get("id")
+            if self._normalize_string(song_title) == normalized_title:
+                return song.get("id")
+
+        return None

--- a/backend/tests/test_navidrome_client.py
+++ b/backend/tests/test_navidrome_client.py
@@ -4,7 +4,7 @@ from youtube_watcher.navidrome_client import NavidromeClient
 
 
 class TestNavidromeClient:
-    def test_make_request_serializes_song_ids_as_repeated_params(self):
+    def test_update_playlist_serializes_song_ids_to_add_as_repeated_params(self):
         client = NavidromeClient("https://example.com", "user", "pass")
 
         with patch("youtube_watcher.navidrome_client.requests.get") as mock_get:
@@ -13,11 +13,25 @@ class TestNavidromeClient:
             response.json.return_value = {"subsonic-response": {"status": "ok"}}
             mock_get.return_value = response
 
-            client.update_playlist("playlist-1", song_ids=["song-1", "song-2"])
+            client.update_playlist("playlist-1", song_ids_to_add=["song-1", "song-2"])
 
         called_params = mock_get.call_args.kwargs["params"]
-        song_params = [item for item in called_params if item[0] == "songId"]
-        assert song_params == [("songId", "song-1"), ("songId", "song-2")]
+        song_params = [item for item in called_params if item[0] == "songIdToAdd"]
+        assert song_params == [("songIdToAdd", "song-1"), ("songIdToAdd", "song-2")]
+
+    def test_start_scan_sends_full_scan_when_requested(self):
+        client = NavidromeClient("https://example.com", "user", "pass")
+
+        with patch("youtube_watcher.navidrome_client.requests.get") as mock_get:
+            response = Mock()
+            response.raise_for_status.return_value = None
+            response.json.return_value = {"subsonic-response": {"status": "ok"}}
+            mock_get.return_value = response
+
+            client.start_scan(full_scan=True)
+
+        called_params = mock_get.call_args.kwargs["params"]
+        assert ("fullScan", "true") in called_params
 
     def test_ensure_playlist_reuses_existing_playlist(self):
         client = NavidromeClient("https://example.com", "user", "pass")

--- a/backend/tests/test_watcher.py
+++ b/backend/tests/test_watcher.py
@@ -117,6 +117,56 @@ class TestYouTubeWatcher:
         # Verificar que se procesó el video con sus respectivos DB arguments
         watcher._process_video.assert_called_once_with({"id": "vid1", "title": "Song"}, 1, db_mock)
 
+    def test_add_song_to_playlist_by_id_uses_song_id_to_add(self, tmp_path):
+        watcher = YouTubeWatcher(str(tmp_path))
+        client = Mock()
+        client.get_playlist_songs.return_value = [{"id": "existing-song"}]
+        client.update_playlist.return_value = True
+
+        watcher._add_song_to_playlist_by_id(
+            client,
+            "playlist-1",
+            "new-song",
+            "Song",
+            "Test Playlist",
+        )
+
+        client.update_playlist.assert_called_once_with("playlist-1", song_ids_to_add=["new-song"])
+
+    @patch("youtube_watcher.watcher.time.sleep", return_value=None)
+    def test_add_to_navidrome_playlist_triggers_scan_and_retries(self, _mock_sleep, tmp_path):
+        watcher = YouTubeWatcher(str(tmp_path))
+        watcher._add_song_to_playlist_by_id = Mock()
+        watcher._find_navidrome_song_id = Mock(side_effect=[None, "song-nav"])
+
+        source = Source(id=1, name="Playlist A", type="playlist", navidrome_playlist_id="pl-source")
+
+        db_mock = MagicMock()
+        db_mock.query.return_value.filter.return_value.first.return_value = source
+
+        client_instance = Mock()
+        client_instance.search_songs.side_effect = [[], [], [{"id": "song-nav", "title": "Song", "comment": ""}]]
+        client_instance.start_scan.return_value = True
+        client_instance.ensure_playlist.side_effect = ["pl-global", "pl-new"]
+
+        with patch("youtube_watcher.navidrome_client.NavidromeClient", return_value=client_instance), \
+             patch("youtube_watcher.db.database.SessionLocal") as mock_session, \
+             patch("os.getenv") as mock_getenv:
+            mock_session.return_value.__enter__.return_value = db_mock
+            env = {
+                "NAVIDROME_URL": "https://music.example.com",
+                "NAVIDROME_USER": "user",
+                "NAVIDROME_PASSWORD": "pass",
+                "NAVIDROME_GLOBAL_PLAYLIST_NAME": "Toda la Musica",
+                "NAVIDROME_NEW_PLAYLIST_NAME": "Lo más nuevo",
+            }
+            mock_getenv.side_effect = lambda key, default=None: env.get(key, default)
+
+            watcher._add_to_navidrome_playlist(1, "yt123", "Song", is_new_download=True)
+
+        client_instance.start_scan.assert_called_once_with()
+        assert watcher._add_song_to_playlist_by_id.call_count == 3
+
 
 class TestPlaylistMonitor:
     """Tests para PlaylistMonitor"""


### PR DESCRIPTION
## Summary
- Fixes Subsonic playlist updates by using `songIdToAdd` for `updatePlaylist` instead of rebuilding playlists with unsupported params.
- Adds Navidrome scan + retry flow when a newly downloaded song is not yet searchable, reducing false "not found" cases in production.
- Improves song matching normalization and keeps playlist linking behavior for source/global/new playlists.

## Why
Playlists were being created but songs were not added because `updatePlaylist` parameter semantics were incorrect and songs were often searched before Navidrome had indexed them.