### PR TITLE
fix: recover from stale Navidrome playlist IDs in sources

### DIFF
--- a/backend/src/youtube_watcher/navidrome_client.py
+++ b/backend/src/youtube_watcher/navidrome_client.py
@@ -159,6 +159,11 @@ class NavidromeClient:
             return result["playlist"].get("entry", [])
         return []
 
+    def playlist_exists(self, playlist_id: str) -> bool:
+        """Check if a playlist exists by ID"""
+        result = self._make_request("getPlaylist", {"id": playlist_id})
+        return bool(result and "playlist" in result)
+
     def search_songs(self, query: str) -> list[dict]:
         """Search for songs in Navidrome"""
         result = self._make_request("search3", {"query": query})

--- a/backend/src/youtube_watcher/watcher.py
+++ b/backend/src/youtube_watcher/watcher.py
@@ -374,10 +374,23 @@ class YouTubeWatcher:
                 with SessionLocal() as db:
                     source = db.query(Source).filter(Source.id == source_id).first()
                     if source and source.type in ("playlist", "artist"):
-                        playlist_id = source.navidrome_playlist_id or client.ensure_playlist(source.name)
-                        if playlist_id and not source.navidrome_playlist_id:
-                            source.navidrome_playlist_id = playlist_id
+                        playlist_id = source.navidrome_playlist_id
+                        if playlist_id and not client.playlist_exists(playlist_id):
+                            logger.warning(
+                                "Stored Navidrome playlist ID '%s' for source '%s' is stale. Re-linking by name.",
+                                playlist_id,
+                                source.name,
+                            )
+                            source.navidrome_playlist_id = None
                             db.commit()
+                            playlist_id = None
+
+                        if not playlist_id:
+                            playlist_id = client.ensure_playlist(source.name)
+                            if playlist_id:
+                                source.navidrome_playlist_id = playlist_id
+                                db.commit()
+
                         if playlist_id:
                             self._add_song_to_playlist_by_id(client, playlist_id, navidrome_song_id, title, source.name)
 

--- a/backend/tests/test_navidrome_client.py
+++ b/backend/tests/test_navidrome_client.py
@@ -33,6 +33,18 @@ class TestNavidromeClient:
         called_params = mock_get.call_args.kwargs["params"]
         assert ("fullScan", "true") in called_params
 
+    def test_playlist_exists_returns_false_when_not_found(self):
+        client = NavidromeClient("https://example.com", "user", "pass")
+        client._make_request = Mock(return_value=None)
+
+        assert client.playlist_exists("missing-id") is False
+
+    def test_playlist_exists_returns_true_when_found(self):
+        client = NavidromeClient("https://example.com", "user", "pass")
+        client._make_request = Mock(return_value={"playlist": {"id": "abc"}})
+
+        assert client.playlist_exists("abc") is True
+
     def test_ensure_playlist_reuses_existing_playlist(self):
         client = NavidromeClient("https://example.com", "user", "pass")
         client.find_playlist_by_name = Mock(return_value={"id": "existing-1", "name": "Lo más nuevo"})

--- a/backend/tests/test_watcher.py
+++ b/backend/tests/test_watcher.py
@@ -167,6 +167,39 @@ class TestYouTubeWatcher:
         client_instance.start_scan.assert_called_once_with()
         assert watcher._add_song_to_playlist_by_id.call_count == 3
 
+    @patch("youtube_watcher.watcher.time.sleep", return_value=None)
+    def test_add_to_navidrome_playlist_relinks_stale_source_playlist_id(self, _mock_sleep, tmp_path):
+        watcher = YouTubeWatcher(str(tmp_path))
+        watcher._add_song_to_playlist_by_id = Mock()
+        watcher._find_navidrome_song_id = Mock(return_value="song-nav")
+
+        source = Source(id=1, name="Lpz List", type="playlist", navidrome_playlist_id="stale-id")
+
+        db_mock = MagicMock()
+        db_mock.query.return_value.filter.return_value.first.return_value = source
+
+        client_instance = Mock()
+        client_instance.playlist_exists.return_value = False
+        client_instance.ensure_playlist.side_effect = ["pl-global", "pl-source-relinked", "pl-new"]
+
+        with patch("youtube_watcher.navidrome_client.NavidromeClient", return_value=client_instance), \
+             patch("youtube_watcher.db.database.SessionLocal") as mock_session, \
+             patch("os.getenv") as mock_getenv:
+            mock_session.return_value.__enter__.return_value = db_mock
+            env = {
+                "NAVIDROME_URL": "https://music.example.com",
+                "NAVIDROME_USER": "user",
+                "NAVIDROME_PASSWORD": "pass",
+                "NAVIDROME_GLOBAL_PLAYLIST_NAME": "Toda la Musica",
+                "NAVIDROME_NEW_PLAYLIST_NAME": "Lo más nuevo",
+            }
+            mock_getenv.side_effect = lambda key, default=None: env.get(key, default)
+
+            watcher._add_to_navidrome_playlist(1, "yt123", "Song", is_new_download=True)
+
+        assert source.navidrome_playlist_id == "pl-source-relinked"
+        assert db_mock.commit.call_count >= 1
+
 
 class TestPlaylistMonitor:
     """Tests para PlaylistMonitor"""


### PR DESCRIPTION
## Summary
- Detects when a source stores a Navidrome playlist ID that no longer exists and relinks it by source name.
- Persists the repaired `navidrome_playlist_id` in DB before continuing song insertion.
- Adds tests for stale-ID recovery and playlist existence checks.

## Why
Production logs show repeated `playlist not found (code: 70)` when adding songs to source playlists. This happens when a source points to a deleted or stale Navidrome playlist ID. The fix self-heals that mapping and avoids repeated add failures.