### PR TITLE
fix: prevent duplicate Navidrome playlists

### DIFF
--- a/backend/src/youtube_watcher/api/routes.py
+++ b/backend/src/youtube_watcher/api/routes.py
@@ -156,6 +156,7 @@ def _sync_existing_tracks_to_navidrome(source_id: int, playlist_id: str, source_
         current_song_ids = {s.get("id") for s in current_songs}
         
         added_count = 0
+        song_ids_to_add = []
         for track in existing_tracks:
             # Search for song in Navidrome
             songs = client.search_songs(track.title)
@@ -168,11 +169,11 @@ def _sync_existing_tracks_to_navidrome(source_id: int, playlist_id: str, source_
             
             if navidrome_song_id and navidrome_song_id not in current_song_ids:
                 current_song_ids.add(navidrome_song_id)
+                song_ids_to_add.append(navidrome_song_id)
                 added_count += 1
         
-        if added_count > 0:
-            all_song_ids = list(current_song_ids)
-            success = client.update_playlist(playlist_id, song_ids=all_song_ids)
+        if song_ids_to_add:
+            success = client.update_playlist(playlist_id, song_ids_to_add=song_ids_to_add)
             if success:
                 logger.info(f"✅ Synced {added_count} existing tracks to Navidrome playlist '{source_name}'")
             else:

--- a/backend/src/youtube_watcher/navidrome_client.py
+++ b/backend/src/youtube_watcher/navidrome_client.py
@@ -24,7 +24,8 @@ class NavidromeClient:
         """Build Subsonic authentication parameters"""
         import random
         import string
-        salt = ''.join(random.choices(string.ascii_letters + string.digits, k=16))
+
+        salt = "".join(random.choices(string.ascii_letters + string.digits, k=16))
         token = hashlib.md5(f"{self.password}{salt}".encode()).hexdigest()
         return {
             "u": self.username,
@@ -49,7 +50,9 @@ class NavidromeClient:
 
         return normalized
 
-    def _make_request(self, endpoint: str, params: Optional[dict] = None, method: str = "GET") -> Optional[dict]:
+    def _make_request(
+        self, endpoint: str, params: Optional[dict] = None, method: str = "GET"
+    ) -> Optional[dict]:
         """Make a request to the Subsonic API"""
         endpoint_path = f"rest/{endpoint}"
         url = urljoin(f"{self.base_url}/", endpoint_path)
@@ -59,13 +62,15 @@ class NavidromeClient:
             response = requests.get(url, params=request_params, timeout=10)
             response.raise_for_status()
             data = response.json()
-            
+
             subsonic_response = data.get("subsonic-response", {})
             if subsonic_response.get("status") != "ok":
                 error = subsonic_response.get("error", {})
-                logger.error(f"Navidrome API error: {error.get('message', 'Unknown')} (code: {error.get('code')})")
+                logger.error(
+                    f"Navidrome API error: {error.get('message', 'Unknown')} (code: {error.get('code')})"
+                )
                 return None
-            
+
             return subsonic_response
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to connect to Navidrome: {e}")
@@ -79,32 +84,83 @@ class NavidromeClient:
         result = self._make_request("ping")
         return result is not None
 
-    def get_playlists(self) -> list[dict]:
-        """Get all playlists from Navidrome"""
+    def get_playlists(self) -> Optional[list[dict]]:
+        """
+        Get all playlists from Navidrome.
+
+        Returns None when the lookup itself fails. This is intentionally
+        distinct from an empty list: callers must not create a playlist when
+        Navidrome timed out or returned an API error, otherwise transient
+        failures create duplicate playlists with the same name.
+        """
         result = self._make_request("getPlaylists")
-        if result and "playlists" in result:
-            return result["playlists"].get("playlist", [])
+        if result is None:
+            return None
+        if "playlists" not in result:
+            return []
+
+        playlists = result["playlists"].get("playlist", [])
+        if isinstance(playlists, dict):
+            return [playlists]
+        if isinstance(playlists, list):
+            return playlists
         return []
+
+    @staticmethod
+    def _playlist_song_count(playlist: dict) -> int:
+        for key in ("songCount", "song_count"):
+            value = playlist.get(key)
+            if value is not None:
+                try:
+                    return int(value)
+                except (TypeError, ValueError):
+                    return 0
+        return 0
+
+    def _find_best_playlist_match(
+        self, playlists: list[dict], name: str
+    ) -> Optional[dict]:
+        normalized_name = name.strip().casefold()
+        matches = [
+            playlist
+            for playlist in playlists
+            if str(playlist.get("name", "")).strip().casefold() == normalized_name
+        ]
+        if not matches:
+            return None
+        return max(matches, key=self._playlist_song_count)
 
     def find_playlist_by_name(self, name: str) -> Optional[dict]:
         """Find a playlist by name"""
         playlists = self.get_playlists()
-        normalized_name = name.strip().casefold()
-        for playlist in playlists:
-            playlist_name = str(playlist.get("name", "")).strip().casefold()
-            if playlist_name == normalized_name:
-                return playlist
-        return None
+        if playlists is None:
+            logger.warning(
+                "Could not fetch Navidrome playlists; refusing to create playlist '%s' blindly",
+                name,
+            )
+            return None
+
+        return self._find_best_playlist_match(playlists, name)
 
     def ensure_playlist(self, name: str) -> Optional[str]:
-        """Find playlist by name or create it if missing"""
-        existing_playlist = self.find_playlist_by_name(name)
+        """Find playlist by name or create it if confirmed missing"""
+        playlists = self.get_playlists()
+        if playlists is None:
+            logger.warning(
+                "Skipping Navidrome playlist creation for '%s' because playlist lookup failed",
+                name,
+            )
+            return None
+
+        existing_playlist = self._find_best_playlist_match(playlists, name)
         if existing_playlist:
             return existing_playlist.get("id")
 
         return self.create_playlist(name)
 
-    def create_playlist(self, name: str, song_ids: Optional[list[str]] = None) -> Optional[str]:
+    def create_playlist(
+        self, name: str, song_ids: Optional[list[str]] = None
+    ) -> Optional[str]:
         """
         Create a new playlist in Navidrome
         Returns the playlist ID if successful, None otherwise

--- a/backend/tests/test_navidrome_client.py
+++ b/backend/tests/test_navidrome_client.py
@@ -47,7 +47,9 @@ class TestNavidromeClient:
 
     def test_ensure_playlist_reuses_existing_playlist(self):
         client = NavidromeClient("https://example.com", "user", "pass")
-        client.find_playlist_by_name = Mock(return_value={"id": "existing-1", "name": "Lo más nuevo"})
+        client.get_playlists = Mock(
+            return_value=[{"id": "existing-1", "name": "Lo más nuevo"}]
+        )
         client.create_playlist = Mock()
 
         playlist_id = client.ensure_playlist("Lo más nuevo")
@@ -57,10 +59,51 @@ class TestNavidromeClient:
 
     def test_ensure_playlist_creates_missing_playlist(self):
         client = NavidromeClient("https://example.com", "user", "pass")
-        client.find_playlist_by_name = Mock(return_value=None)
+        client.get_playlists = Mock(return_value=[])
         client.create_playlist = Mock(return_value="new-1")
 
         playlist_id = client.ensure_playlist("Toda la Musica")
 
         assert playlist_id == "new-1"
         client.create_playlist.assert_called_once_with("Toda la Musica")
+
+    def test_get_playlists_returns_none_when_lookup_fails(self):
+        client = NavidromeClient("https://example.com", "user", "pass")
+        client._make_request = Mock(return_value=None)
+
+        assert client.get_playlists() is None
+
+    def test_ensure_playlist_does_not_create_when_lookup_fails(self):
+        client = NavidromeClient("https://example.com", "user", "pass")
+        client.get_playlists = Mock(return_value=None)
+        client.create_playlist = Mock(return_value="should-not-create")
+
+        playlist_id = client.ensure_playlist("Toda la Musica")
+
+        assert playlist_id is None
+        client.create_playlist.assert_not_called()
+
+    def test_get_playlists_normalizes_single_playlist_response(self):
+        client = NavidromeClient("https://example.com", "user", "pass")
+        client._make_request = Mock(
+            return_value={
+                "playlists": {"playlist": {"id": "one", "name": "Toda la Musica"}}
+            }
+        )
+
+        assert client.get_playlists() == [{"id": "one", "name": "Toda la Musica"}]
+
+    def test_ensure_playlist_reuses_largest_matching_playlist_when_duplicates_exist(
+        self,
+    ):
+        client = NavidromeClient("https://example.com", "user", "pass")
+        client.get_playlists = Mock(
+            return_value=[
+                {"id": "duplicate-small", "name": "Toda la Musica", "songCount": 1},
+                {"id": "canonical-large", "name": "Toda la Musica", "songCount": 452},
+            ]
+        )
+        client.create_playlist = Mock()
+
+        assert client.ensure_playlist("Toda la Musica") == "canonical-large"
+        client.create_playlist.assert_not_called()


### PR DESCRIPTION
## Summary
- Prevent `ensure_playlist()` from creating a Navidrome playlist when `getPlaylists` fails or times out.
- Normalize single-playlist Subsonic responses and reuse the largest matching playlist when duplicates already exist.
- Fix existing-track sync to call `update_playlist(..., song_ids_to_add=...)` instead of the invalid `song_ids` keyword.
- Add regression tests for failed playlist lookup, single-playlist normalization, and duplicate-name reuse.

## Root cause
`get_playlists()` returned `[]` both for "no playlists" and for Navidrome/API failures. `ensure_playlist()` interpreted that as "missing playlist" and called `createPlaylist`, causing duplicate `Toda la Musica` playlists during transient Navidrome timeouts.

## Test plan
- `backend/.venv/bin/python -m pytest backend/tests -q`

Result: 33 passed, 1 skipped, 1 warning.
