### PR TITLE
fix: make Navidrome playlist additions idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ El frontend en desarrollo correrá en el puerto `5173` y estará configurado par
 El proyecto utiliza GitHub Actions integradas con `ArkeonProject/organization-tools`.
 
 - **CI (`ci.yml`)**: Verifica linting, tipos de TypeScript, y ejecuta tests de Python para cualquier PR hacia `develop` o `main`.
-- **CD (`cd.yml`)**: Al hacer push a `main`, construye y publica las imágenes Docker duales (`ghcr.io/.../backend` y `ghcr.io/.../frontend`) en GHCR de forma automática.
+- **CD (`cd.yml`)**: Al hacer push a `main`, construye y publica las imágenes Docker duales (`ghcr.io/.../backend` y `ghcr.io/.../frontend`) en GHCR. Si Portainer usa tags fijos por SHA en su compose, el webhook no actualiza esos tags automáticamente; consulta [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md#actualizaciones-y-cicd) antes de asumir que producción quedó desplegada.
 
 ## 📄 Licencia
 

--- a/backend/src/youtube_watcher/api/routes.py
+++ b/backend/src/youtube_watcher/api/routes.py
@@ -153,6 +153,13 @@ def _sync_existing_tracks_to_navidrome(source_id: int, playlist_id: str, source_
         
         # Get current playlist songs
         current_songs = client.get_playlist_songs(playlist_id)
+        if current_songs is None:
+            logger.warning(
+                "Could not fetch current songs for Navidrome playlist '%s'; skipping existing-track sync to avoid duplicates",
+                source_name,
+            )
+            return
+
         current_song_ids = {s.get("id") for s in current_songs}
         
         added_count = 0

--- a/backend/src/youtube_watcher/navidrome_client.py
+++ b/backend/src/youtube_watcher/navidrome_client.py
@@ -188,7 +188,10 @@ class NavidromeClient:
         if name:
             params["name"] = name
         if song_ids_to_add:
-            params["songIdToAdd"] = song_ids_to_add
+            # Navidrome accepts duplicate songIdToAdd values and will create
+            # duplicate playlist rows. Deduplicate inside a single request while
+            # preserving order so accidental repeated IDs are idempotent.
+            params["songIdToAdd"] = list(dict.fromkeys(song_ids_to_add))
         if song_indexes_to_remove:
             params["songIndexToRemove"] = song_indexes_to_remove
 
@@ -208,11 +211,26 @@ class NavidromeClient:
             logger.info(f"Deleted Navidrome playlist ID: {playlist_id}")
         return result is not None
 
-    def get_playlist_songs(self, playlist_id: str) -> list[dict]:
-        """Get all songs in a playlist"""
+    def get_playlist_songs(self, playlist_id: str) -> Optional[list[dict]]:
+        """
+        Get all songs in a playlist.
+
+        Returns None when the playlist lookup fails. This is intentionally
+        distinct from an empty list: callers must not add songs when Navidrome
+        timed out or returned an API error, otherwise transient lookup failures
+        create duplicate playlist rows.
+        """
         result = self._make_request("getPlaylist", {"id": playlist_id})
-        if result and "playlist" in result:
-            return result["playlist"].get("entry", [])
+        if result is None:
+            return None
+        if "playlist" not in result:
+            return []
+
+        entries = result["playlist"].get("entry", [])
+        if isinstance(entries, dict):
+            return [entries]
+        if isinstance(entries, list):
+            return entries
         return []
 
     def playlist_exists(self, playlist_id: str) -> bool:

--- a/backend/src/youtube_watcher/watcher.py
+++ b/backend/src/youtube_watcher/watcher.py
@@ -407,6 +407,15 @@ class YouTubeWatcher:
         """Add song to playlist by ID, avoiding duplicates"""
         try:
             current_songs = client.get_playlist_songs(playlist_id)
+            if current_songs is None:
+                logger.warning(
+                    "Could not fetch songs for Navidrome playlist '%s' (%s); skipping add for '%s' to avoid duplicates",
+                    playlist_label,
+                    playlist_id,
+                    title,
+                )
+                return
+
             current_song_ids = [s.get("id") for s in current_songs]
             
             if song_id in current_song_ids:

--- a/backend/tests/test_navidrome_client.py
+++ b/backend/tests/test_navidrome_client.py
@@ -107,3 +107,36 @@ class TestNavidromeClient:
 
         assert client.ensure_playlist("Toda la Musica") == "canonical-large"
         client.create_playlist.assert_not_called()
+
+    def test_get_playlist_songs_returns_none_when_lookup_fails(self):
+        client = NavidromeClient("https://example.com", "user", "pass")
+        client._make_request = Mock(return_value=None)
+
+        assert client.get_playlist_songs("playlist-1") is None
+
+    def test_get_playlist_songs_normalizes_single_entry_response(self):
+        client = NavidromeClient("https://example.com", "user", "pass")
+        client._make_request = Mock(
+            return_value={"playlist": {"entry": {"id": "song-1", "title": "Song"}}}
+        )
+
+        assert client.get_playlist_songs("playlist-1") == [
+            {"id": "song-1", "title": "Song"}
+        ]
+
+    def test_update_playlist_deduplicates_song_ids_to_add_within_request(self):
+        client = NavidromeClient("https://example.com", "user", "pass")
+
+        with patch("youtube_watcher.navidrome_client.requests.get") as mock_get:
+            response = Mock()
+            response.raise_for_status.return_value = None
+            response.json.return_value = {"subsonic-response": {"status": "ok"}}
+            mock_get.return_value = response
+
+            client.update_playlist(
+                "playlist-1", song_ids_to_add=["song-1", "song-1", "song-2"]
+            )
+
+        called_params = mock_get.call_args.kwargs["params"]
+        song_params = [item for item in called_params if item[0] == "songIdToAdd"]
+        assert song_params == [("songIdToAdd", "song-1"), ("songIdToAdd", "song-2")]

--- a/backend/tests/test_watcher.py
+++ b/backend/tests/test_watcher.py
@@ -133,6 +133,21 @@ class TestYouTubeWatcher:
 
         client.update_playlist.assert_called_once_with("playlist-1", song_ids_to_add=["new-song"])
 
+    def test_add_song_to_playlist_by_id_skips_when_playlist_lookup_fails(self, tmp_path):
+        watcher = YouTubeWatcher(str(tmp_path))
+        client = Mock()
+        client.get_playlist_songs.return_value = None
+
+        watcher._add_song_to_playlist_by_id(
+            client,
+            "playlist-1",
+            "song-1",
+            "Song",
+            "Test Playlist",
+        )
+
+        client.update_playlist.assert_not_called()
+
     @patch("youtube_watcher.watcher.time.sleep", return_value=None)
     def test_add_to_navidrome_playlist_triggers_scan_and_retries(self, _mock_sleep, tmp_path):
         watcher = YouTubeWatcher(str(tmp_path))

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,11 +67,41 @@ El backend requiere persistencia de datos crucial.
 
 ## Actualizaciones y CI/CD
 
-El pipeline CI/CD de GitHub empuja dos imágenes concurrentes cuando se completan merges hacia `main`:
-- `ghcr.io/arkeonproject/arkeon-music-downloader/backend`
-- `ghcr.io/arkeonproject/arkeon-music-downloader/frontend`
+El workflow `.github/workflows/cd.yml` se ejecuta en cada push a `main` y delega en
+`ArkeonProject/organization-tools/.github/workflows/reusable-docker-build.yml` para
+construir y publicar dos imágenes en GHCR:
 
-Para actualizar tu servidor (sin dependencias de watchtower):
+- `ghcr.io/arkeonproject/arkeon-music-downloader/backend:<sha-corto>`
+- `ghcr.io/arkeonproject/arkeon-music-downloader/frontend:<sha-corto>`
+
+El mismo workflow puede llamar a los webhooks configurados en los secretos
+`PORTAINER_WEBHOOK_BACKEND` y `PORTAINER_WEBHOOK_FRONTEND`, pero hay una limitación
+importante: **un webhook de Portainer solo repuebla/recrea el stack con el compose
+que Portainer ya tiene guardado**. Si ese compose usa tags estáticos por commit
+como `backend:e598b5d` y `frontend:e598b5d`, el webhook no cambia el
+`StackFileContent` a `backend:<nuevo-sha>` / `frontend:<nuevo-sha>` por sí solo.
+
+Por tanto, el despliegue automático requiere una de estas estrategias:
+
+1. **Tags móviles**: el compose de Portainer referencia un tag estable, por ejemplo
+   `main` o `latest`, y el CD publica ese tag además del SHA. El webhook hace
+   `pull`/redeploy del mismo tag.
+2. **Actualización explícita del stack**: el CD o un operador actualiza el
+   `StackFileContent` de Portainer para sustituir ambos tags por el nuevo SHA y
+   redeployar el stack.
+
+Mientras el stack de producción esté fijado a tags SHA, después de cada merge a
+`main` hay que verificar que Portainer quedó apuntando al SHA nuevo. Una comprobación
+rápida es revisar el stack file o los contenedores en ejecución:
+
+```bash
+# Ejemplo con Docker directo en el host
+docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}' \
+  | grep music-downloader
+```
+
+Para actualizar un servidor Docker Compose sin Portainer ni watchtower:
+
 ```bash
 docker compose pull
 docker compose up -d


### PR DESCRIPTION
## Summary
- Make `get_playlist_songs()` distinguish Navidrome lookup failures (`None`) from empty playlists (`[]`)
- Normalize single-song Subsonic playlist responses to a list
- Skip playlist additions when current songs cannot be fetched, avoiding duplicate rows on transient Navidrome failures
- Deduplicate repeated `songIdToAdd` values inside one update request

## Test plan
- `cd backend && . .venv/bin/activate && pytest -q`

## Production cleanup already performed
- Cleaned duplicate rows in Navidrome `Toda la Musica`: 902 rows -> 454 unique songs
- DB backup created before cleanup
