### PR TITLE
fix: stop repeated Navidrome sync for completed tracks

### DIFF
--- a/backend/src/youtube_watcher/watcher.py
+++ b/backend/src/youtube_watcher/watcher.py
@@ -144,12 +144,11 @@ class YouTubeWatcher:
         
         if existing_track:
             if existing_track.download_status == "completed":
-                self._add_to_navidrome_playlist(
-                    source_id,
-                    existing_track.youtube_id,
-                    existing_track.title,
-                    is_new_download=False,
-                )
+                # Completed tracks are already downloaded and were synced to Navidrome
+                # at download time (or via the explicit startup/source sync paths).
+                # Retrying Navidrome playlist sync on every watcher pass causes
+                # repeated scans when a historical file cannot be found in Navidrome,
+                # which makes "recent/new" views churn continuously.
                 return
             if existing_track.download_status == "ignored":
                 return

--- a/backend/tests/test_watcher.py
+++ b/backend/tests/test_watcher.py
@@ -83,14 +83,11 @@ class TestYouTubeWatcher:
         
         watcher._process_video(video_data, source_id=1, db=db_mock)
 
-        # No se debe intentar descargar si ya está "completed"
+        # No se debe intentar descargar ni re-sincronizar Navidrome en cada pasada.
+        # Las canciones completadas se añaden a Navidrome al descargarse o mediante
+        # los flujos explícitos de sync, no desde el watcher continuo.
         watcher.downloader.download_and_convert.assert_not_called()
-        watcher._add_to_navidrome_playlist.assert_called_once_with(
-            1,
-            "abc123",
-            "Song",
-            is_new_download=False,
-        )
+        watcher._add_to_navidrome_playlist.assert_not_called()
 
     @patch("youtube_watcher.watcher.PlaylistMonitor")
     @patch("youtube_watcher.watcher.SessionLocal")


### PR DESCRIPTION
## Summary
- stop the continuous watcher from re-syncing already completed tracks to Navidrome on every pass
- keep Navidrome playlist addition for genuinely new downloads and explicit startup/source sync flows
- update the watcher regression test to guard against repeated completed-track syncs

## Verification
- `PYTHONPATH=backend/src backend/venv/bin/python -m pytest backend/tests/test_watcher.py backend/tests/test_navidrome_client.py -q` → 26 passed
- `PYTHONPATH=backend/src backend/venv/bin/python -m pytest -q` → 37 passed, 1 skipped
- `git diff --check` → clean

Note: focused flake8 on these files still reports pre-existing style issues across the files; this patch does not introduce whitespace errors (`git diff --check` is clean).